### PR TITLE
fix: 固定 Jenkins 的 Node 與 Python 工具版本

### DIFF
--- a/scripts/jenkins-build.sh
+++ b/scripts/jenkins-build.sh
@@ -6,7 +6,9 @@ ACTION="${1:-}"
 OUTPUT_DIR="${2:-}"
 STATE_DIR=".jenkins-release"
 TOOLS_ROOT="${ZHTW_TOOLS_ROOT:-$HOME/.local/share/zhtw-tools}"
-export PATH="$HOME/.cargo/bin:$TOOLS_ROOT/dotnet:$TOOLS_ROOT/go/bin:$TOOLS_ROOT/wasm-pack:$PATH"
+export PATH="$TOOLS_ROOT/node-20/bin:$HOME/.cargo/bin:$TOOLS_ROOT/dotnet:$TOOLS_ROOT/go/bin:$TOOLS_ROOT/wasm-pack:$PATH"
+export UV_PYTHON=3.13
+export UV_PYTHON_PREFERENCE=only-managed
 
 die() {
     printf 'ERROR: %s\n' "$*" >&2


### PR DESCRIPTION
## 內容
- 候選建置固定使用 Jenkins 安裝的 Node 20
- uv 固定使用 managed Python 3.13
- pnpm 由 Jenkins 工具安裝器提供

## 驗證
- 9 項發布流程測試通過
- shell syntax 與 diff check 通過
- 不執行公開發布