### PR TITLE
fix: 修正 Jenkins 發布紀錄解析

### DIFF
--- a/scripts/prepare_release_candidate.py
+++ b/scripts/prepare_release_candidate.py
@@ -50,7 +50,7 @@ def main() -> None:
         changelog.write_text(text, encoding="utf-8")
 
     notes_match = re.search(
-        rf"^## \[{re.escape(args.version)}\](?: - .*)?\n(?P<body>.*?)(?=^## \[|\Z)",
+        rf"^## \[{re.escape(args.version)}\](?: - [^\n]*)?\n(?P<body>.*?)(?=^## \[|\Z)",
         text,
         re.MULTILINE | re.DOTALL,
     )

--- a/tests/test_release_process.py
+++ b/tests/test_release_process.py
@@ -121,6 +121,29 @@ def test_version_bump_is_portable(tmp_path: Path) -> None:
     assert "sed -i ''" not in read("Makefile")
 
 
+def test_release_candidate_keeps_unreleased_notes(tmp_path: Path) -> None:
+    shutil.copy2(ROOT / "CHANGELOG.md", tmp_path / "CHANGELOG.md")
+    notes = tmp_path / "release-notes.md"
+
+    subprocess.run(
+        [
+            "python3",
+            str(ROOT / "scripts/prepare_release_candidate.py"),
+            "--version",
+            "9.8.7",
+            "--date",
+            "2026-08-09",
+            "--notes-output",
+            str(notes),
+        ],
+        cwd=tmp_path,
+        check=True,
+    )
+
+    assert "Blind-v3" in notes.read_text(encoding="utf-8")
+    assert "## [9.8.7] - 2026-08-09" in (tmp_path / "CHANGELOG.md").read_text(encoding="utf-8")
+
+
 def test_release_gate_uses_pinned_corpus_and_go_lint() -> None:
     makefile = read("Makefile")
     lock = read("tests/data/corpus.lock").strip()


### PR DESCRIPTION
## 原因
release notes regex 在 DOTALL 模式用 `.*` 解析日期，誤吞整段內容，導致 build #2 把非空的 Unreleased 誤判為空。

## 修正
- 日期只允許讀取單行
- 新增實際產生 9.8.7 notes 並檢查 Blind-v3 內容的回歸測試

## 驗證
- 10 項發布流程測試通過
- Ruff 與格式檢查通過
- 沒有執行公開發布