### PR TITLE
fix: 升版時同步 benchmark 本機鎖定

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -543,6 +543,7 @@ endif
 	@mkdir -p sdk/rust/zhtw/data
 	@cp sdk/data/zhtw-data.json sdk/rust/zhtw/data/zhtw-data.json
 	@cp sdk/data/zhtw-data.json sdk/go/zhtw/zhtw-data.json
+	@$(PYTHON) scripts/update_local_benchmark_lock.py "$(VERSION)"
 	@echo "🔒 Refreshing Cargo.lock..."
 	@cd sdk/rust && cargo check --quiet 2>/dev/null || true
 	@$(MAKE) version-check

--- a/scripts/update_local_benchmark_lock.py
+++ b/scripts/update_local_benchmark_lock.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+"""Bind the local zhtw benchmark entry to the mono-versioned SDK data."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import re
+from pathlib import Path
+
+SEMVER = re.compile(r"^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$")
+LOCK_PATH = Path("benchmarks/accuracy/competitors.lock.json")
+DATA_PATH = Path("sdk/data/zhtw-data.json")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("version")
+    args = parser.parse_args()
+    if not SEMVER.fullmatch(args.version):
+        raise SystemExit(f"Version must be stable SemVer X.Y.Z, got: {args.version}")
+
+    data = json.loads(DATA_PATH.read_text(encoding="utf-8"))
+    if data.get("version") != args.version:
+        raise SystemExit(
+            f"{DATA_PATH} version is {data.get('version')!r}, expected {args.version!r}"
+        )
+    digest = hashlib.sha256(DATA_PATH.read_bytes()).hexdigest()
+
+    lock = json.loads(LOCK_PATH.read_text(encoding="utf-8"))
+    matches = [item for item in lock.get("competitors", []) if item.get("id") == "zhtw"]
+    if len(matches) != 1:
+        raise SystemExit("competitors lock must contain exactly one zhtw entry")
+    local = matches[0]
+    artifact_hashes = local.get("artifact_sha256")
+    if local.get("adapter") != "local_python" or set(artifact_hashes or {}) != {str(DATA_PATH)}:
+        raise SystemExit("zhtw benchmark entry does not match the reviewed local adapter contract")
+
+    local["version"] = args.version
+    artifact_hashes[str(DATA_PATH)] = digest
+    local["config_sha256"] = digest
+    LOCK_PATH.write_text(
+        json.dumps(lock, ensure_ascii=False, indent=2) + "\n",
+        encoding="utf-8",
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_release_process.py
+++ b/tests/test_release_process.py
@@ -1,5 +1,7 @@
 """Regression tests for the Jenkins-only release pipeline."""
 
+import hashlib
+import json
 import re
 import shutil
 import subprocess
@@ -139,9 +141,32 @@ def test_release_candidate_keeps_unreleased_notes(tmp_path: Path) -> None:
         cwd=tmp_path,
         check=True,
     )
-
     assert "Blind-v3" in notes.read_text(encoding="utf-8")
     assert "## [9.8.7] - 2026-08-09" in (tmp_path / "CHANGELOG.md").read_text(encoding="utf-8")
+
+
+def test_version_bump_refreshes_local_benchmark_lock(tmp_path: Path) -> None:
+    lock_path = tmp_path / "benchmarks/accuracy/competitors.lock.json"
+    data_path = tmp_path / "sdk/data/zhtw-data.json"
+    lock_path.parent.mkdir(parents=True)
+    data_path.parent.mkdir(parents=True)
+    shutil.copy2(ROOT / "benchmarks/accuracy/competitors.lock.json", lock_path)
+    payload = json.loads((ROOT / "sdk/data/zhtw-data.json").read_text(encoding="utf-8"))
+    payload["version"] = "9.8.7"
+    data_path.write_text(json.dumps(payload, ensure_ascii=False) + "\n", encoding="utf-8")
+
+    subprocess.run(
+        ["python3", str(ROOT / "scripts/update_local_benchmark_lock.py"), "9.8.7"],
+        cwd=tmp_path,
+        check=True,
+    )
+
+    lock = json.loads(lock_path.read_text(encoding="utf-8"))
+    local = next(item for item in lock["competitors"] if item["id"] == "zhtw")
+    digest = hashlib.sha256(data_path.read_bytes()).hexdigest()
+    assert local["version"] == "9.8.7"
+    assert local["artifact_sha256"]["sdk/data/zhtw-data.json"] == digest
+    assert local["config_sha256"] == digest
 
 
 def test_release_gate_uses_pinned_corpus_and_go_lint() -> None:


### PR DESCRIPTION
## 原因
Jenkins 候選升版會重建 sdk/data，內嵌版本改變後 SHA-256 必然不同；舊 make bump 沒同步 competitors lock，build #3 因此正確停止。

## 修正
- make bump 同步 zhtw local competitor 的版本、artifact hash 與 config hash
- 嚴格檢查 adapter 與唯一 artifact contract
- 歷史 preregistration lock hash 保持不變

## 驗證
- 11 項發布流程測試通過
- 新測試驗證版本與兩個 SHA 欄位
- Ruff、格式與 diff check 通過