### PR TITLE
fix: 僅在結果不變時推進冪等基線版本

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -544,6 +544,7 @@ endif
 	@cp sdk/data/zhtw-data.json sdk/rust/zhtw/data/zhtw-data.json
 	@cp sdk/data/zhtw-data.json sdk/go/zhtw/zhtw-data.json
 	@$(PYTHON) scripts/update_local_benchmark_lock.py "$(VERSION)"
+	@$(PYTHON) scripts/update_idempotency_baseline_version.py "$(VERSION)"
 	@echo "🔒 Refreshing Cargo.lock..."
 	@cd sdk/rust && cargo check --quiet 2>/dev/null || true
 	@$(MAKE) version-check

--- a/scripts/update_idempotency_baseline_version.py
+++ b/scripts/update_idempotency_baseline_version.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+"""Advance the idempotency baseline version only when every result is unchanged."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+from dataclasses import asdict
+from pathlib import Path
+
+from scripts.audit_corpus_idempotency import build_summary
+
+SEMVER = re.compile(r"^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$")
+DEFAULT_INPUTS = Path("benchmarks/accuracy/blind-v2.inputs.json")
+DEFAULT_BASELINE = Path("benchmarks/accuracy/blind-v2.idempotency-baseline.json")
+
+
+def update_baseline(version: str, inputs_path: Path, baseline_path: Path) -> None:
+    if not SEMVER.fullmatch(version):
+        raise ValueError(f"Version must be stable SemVer X.Y.Z, got: {version}")
+    summary = asdict(build_summary(inputs_path))
+    if summary["converter_version"] != version:
+        raise ValueError(
+            f"loaded converter is {summary['converter_version']!r}, expected {version!r}"
+        )
+
+    baseline = json.loads(baseline_path.read_text(encoding="utf-8"))
+    expected = {key: value for key, value in baseline.items() if key != "converter_version"}
+    actual = {key: value for key, value in summary.items() if key != "converter_version"}
+    if expected != actual:
+        changed = sorted(
+            key for key in set(expected) | set(actual) if expected.get(key) != actual.get(key)
+        )
+        raise ValueError(
+            "idempotency results changed; review before advancing the baseline: "
+            + ", ".join(changed)
+        )
+
+    baseline["converter_version"] = version
+    baseline_path.write_text(
+        json.dumps(baseline, ensure_ascii=False, indent=2) + "\n",
+        encoding="utf-8",
+    )
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("version")
+    parser.add_argument("--inputs", type=Path, default=DEFAULT_INPUTS)
+    parser.add_argument("--baseline", type=Path, default=DEFAULT_BASELINE)
+    args = parser.parse_args()
+    try:
+        update_baseline(args.version, args.inputs, args.baseline)
+    except (OSError, ValueError, json.JSONDecodeError) as exc:
+        raise SystemExit(str(exc)) from exc
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_release_process.py
+++ b/tests/test_release_process.py
@@ -5,7 +5,13 @@ import json
 import re
 import shutil
 import subprocess
+from dataclasses import asdict
 from pathlib import Path
+
+import pytest
+
+import scripts.audit_corpus_idempotency as idempotency_audit
+import scripts.update_idempotency_baseline_version as baseline_updater
 
 ROOT = Path(__file__).resolve().parents[1]
 
@@ -167,6 +173,61 @@ def test_version_bump_refreshes_local_benchmark_lock(tmp_path: Path) -> None:
     assert local["version"] == "9.8.7"
     assert local["artifact_sha256"]["sdk/data/zhtw-data.json"] == digest
     assert local["config_sha256"] == digest
+
+
+def test_version_bump_advances_only_an_unchanged_idempotency_baseline(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    inputs = tmp_path / "inputs.json"
+    baseline = tmp_path / "baseline.json"
+    inputs.write_text("{}\n", encoding="utf-8")
+    summary = idempotency_audit.Summary(
+        schema_version=1,
+        dataset="fixture",
+        converter_version="9.8.7",
+        inputs_sha256="a" * 64,
+        total_cases=10,
+        idempotent_cases=9,
+        non_idempotent_cases=1,
+        idempotency_rate=0.9,
+        non_idempotent_ids_sha256="b" * 64,
+    )
+    payload = asdict(summary)
+    payload["converter_version"] = "4.4.3"
+    baseline.write_text(json.dumps(payload), encoding="utf-8")
+    monkeypatch.setattr(baseline_updater, "build_summary", lambda _: summary)
+
+    baseline_updater.update_baseline("9.8.7", inputs, baseline)
+
+    updated = json.loads(baseline.read_text(encoding="utf-8"))
+    assert updated == asdict(summary)
+
+
+def test_version_bump_rejects_changed_idempotency_results(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    inputs = tmp_path / "inputs.json"
+    baseline = tmp_path / "baseline.json"
+    inputs.write_text("{}\n", encoding="utf-8")
+    summary = idempotency_audit.Summary(
+        schema_version=1,
+        dataset="fixture",
+        converter_version="9.8.7",
+        inputs_sha256="a" * 64,
+        total_cases=10,
+        idempotent_cases=9,
+        non_idempotent_cases=1,
+        idempotency_rate=0.9,
+        non_idempotent_ids_sha256="b" * 64,
+    )
+    payload = asdict(summary)
+    payload["converter_version"] = "4.4.3"
+    payload["idempotent_cases"] = 8
+    baseline.write_text(json.dumps(payload), encoding="utf-8")
+    monkeypatch.setattr(baseline_updater, "build_summary", lambda _: summary)
+
+    with pytest.raises(ValueError, match="idempotent_cases"):
+        baseline_updater.update_baseline("9.8.7", inputs, baseline)
 
 
 def test_release_gate_uses_pinned_corpus_and_go_lint() -> None:


### PR DESCRIPTION
## 原因
候選升到 4.4.4 後，blind-v2 結果仍為 1915/1960 與相同 failure-ID hash，但 baseline 版本仍鎖 4.4.3，build #4 因此停止。

## 安全規則
- 只允許更新 converter_version
- total、idempotent 數量、rate、inputs hash 與 failure-ID hash 必須全部完全相同
- 任一結果改變就 fail closed，要求人工 review

## 驗證
- 13 項發布流程測試通過
- 正向與故意改變 idempotent_cases 的負向測試都通過
- Ruff、格式與 diff check 通過