### PR TITLE
fix: 支援直接執行冪等基線更新器

### DIFF
--- a/scripts/update_idempotency_baseline_version.py
+++ b/scripts/update_idempotency_baseline_version.py
@@ -6,10 +6,14 @@ from __future__ import annotations
 import argparse
 import json
 import re
+import sys
 from dataclasses import asdict
 from pathlib import Path
 
-from scripts.audit_corpus_idempotency import build_summary
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(PROJECT_ROOT))
+
+from scripts.audit_corpus_idempotency import build_summary  # noqa: E402
 
 SEMVER = re.compile(r"^(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)\.(0|[1-9][0-9]*)$")
 DEFAULT_INPUTS = Path("benchmarks/accuracy/blind-v2.inputs.json")

--- a/tests/test_release_process.py
+++ b/tests/test_release_process.py
@@ -230,6 +230,27 @@ def test_version_bump_rejects_changed_idempotency_results(
         baseline_updater.update_baseline("9.8.7", inputs, baseline)
 
 
+def test_idempotency_baseline_updater_runs_as_a_script(tmp_path: Path) -> None:
+    baseline = tmp_path / "baseline.json"
+    shutil.copy2(ROOT / "benchmarks/accuracy/blind-v2.idempotency-baseline.json", baseline)
+
+    subprocess.run(
+        [
+            "python3",
+            str(ROOT / "scripts/update_idempotency_baseline_version.py"),
+            "4.4.3",
+            "--inputs",
+            str(ROOT / "benchmarks/accuracy/blind-v2.inputs.json"),
+            "--baseline",
+            str(baseline),
+        ],
+        cwd=tmp_path,
+        check=True,
+    )
+
+    assert json.loads(baseline.read_text(encoding="utf-8"))["converter_version"] == "4.4.3"
+
+
 def test_release_gate_uses_pinned_corpus_and_go_lint() -> None:
     makefile = read("Makefile")
     lock = read("tests/data/corpus.lock").strip()


### PR DESCRIPTION
## 原因
從 repo root import 的單元測試會通過，但 Jenkins 直接執行 scripts/update_idempotency_baseline_version.py 時，sys.path 缺少 repo root，build #5 因此停止。

## 修正
- 明確加入 script 所屬 repo root
- 新增從臨時工作目錄直接執行 CLI 的回歸測試

## 驗證
- 14 項發布流程測試通過
- CLI 測試實際處理完整 1,960 筆 blind-v2 inputs
- Ruff、格式與 diff check 通過