### PR TITLE
修正 Jenkins 候選版測試的版本相依

### DIFF
--- a/tests/test_accuracy_holdout_post_review.py
+++ b/tests/test_accuracy_holdout_post_review.py
@@ -3,6 +3,7 @@
 """Blind-v1 post-review and public promotion tests."""
 
 from tests._accuracy_holdout_support import *  # noqa: F403
+from zhtw import __version__ as ZHTW_VERSION
 
 
 def test_batch7_miss_final_decision_omits_sealed_values() -> None:
@@ -2597,7 +2598,7 @@ def test_run_accuracy_benchmark_with_temp_fixture(tmp_path: Path) -> None:
     assert "rows" not in payload
     assert "expected" not in payload
     assert payload["expected_sha256"] == hashlib.sha256(expected_path.read_bytes()).hexdigest()
-    assert payload["provenance"]["zhtw_version"] == "4.4.3"
+    assert payload["provenance"]["zhtw_version"] == ZHTW_VERSION
     assert len(payload["provenance"]["git_sha"]) == 40
     assert payload["provenance"]["python_version"]
     assert payload["provenance"]["os"]

--- a/tests/test_release_process.py
+++ b/tests/test_release_process.py
@@ -130,7 +130,15 @@ def test_version_bump_is_portable(tmp_path: Path) -> None:
 
 
 def test_release_candidate_keeps_unreleased_notes(tmp_path: Path) -> None:
-    shutil.copy2(ROOT / "CHANGELOG.md", tmp_path / "CHANGELOG.md")
+    (tmp_path / "CHANGELOG.md").write_text(
+        "# Changelog\n\n"
+        "## [Unreleased]\n\n"
+        "### Changed\n\n"
+        "- Candidate fixture note.\n\n"
+        "## [1.0.0] - 2026-01-01\n\n"
+        "- Previous release.\n",
+        encoding="utf-8",
+    )
     notes = tmp_path / "release-notes.md"
 
     subprocess.run(
@@ -147,7 +155,7 @@ def test_release_candidate_keeps_unreleased_notes(tmp_path: Path) -> None:
         cwd=tmp_path,
         check=True,
     )
-    assert "Blind-v3" in notes.read_text(encoding="utf-8")
+    assert "Candidate fixture note." in notes.read_text(encoding="utf-8")
     assert "## [9.8.7] - 2026-08-09" in (tmp_path / "CHANGELOG.md").read_text(encoding="utf-8")
 
 
@@ -238,7 +246,7 @@ def test_idempotency_baseline_updater_runs_as_a_script(tmp_path: Path) -> None:
         [
             "python3",
             str(ROOT / "scripts/update_idempotency_baseline_version.py"),
-            "4.4.3",
+            idempotency_audit.__version__,
             "--inputs",
             str(ROOT / "benchmarks/accuracy/blind-v2.inputs.json"),
             "--baseline",
@@ -248,7 +256,10 @@ def test_idempotency_baseline_updater_runs_as_a_script(tmp_path: Path) -> None:
         check=True,
     )
 
-    assert json.loads(baseline.read_text(encoding="utf-8"))["converter_version"] == "4.4.3"
+    assert (
+        json.loads(baseline.read_text(encoding="utf-8"))["converter_version"]
+        == idempotency_audit.__version__
+    )
 
 
 def test_release_gate_uses_pinned_corpus_and_go_lint() -> None:


### PR DESCRIPTION
讓候選版測試使用目前套件版本，並以獨立 changelog fixture 驗證發布說明。這可避免 Jenkins 建立下一個 patch 候選版時，被寫死的舊版號或候選工作樹中的空 Unreleased 區塊誤判。\n\n驗證：\n- uv run ruff check tests/test_accuracy_holdout_post_review.py tests/test_release_process.py\n- uv run ruff format --check tests/test_accuracy_holdout_post_review.py tests/test_release_process.py\n- uv run pytest tests/test_release_process.py tests/test_accuracy_holdout_post_review.py::test_run_accuracy_benchmark_with_temp_fixture -q