### PR TITLE
修正 Jenkins NuGet 候選套件建置順序

### DIFF
--- a/scripts/jenkins-build.sh
+++ b/scripts/jenkins-build.sh
@@ -123,7 +123,9 @@ package_crate() {
 package_nuget() {
     local destination="$1"
     mkdir -p "$destination"
-    dotnet pack sdk/dotnet/Zhtw.csproj -c Release --no-build -o "$destination"
+    dotnet restore sdk/dotnet/Zhtw.csproj
+    dotnet build sdk/dotnet/Zhtw.csproj -c Release --no-restore
+    dotnet pack sdk/dotnet/Zhtw.csproj -c Release --no-build --no-restore -o "$destination"
 }
 
 package_maven() {

--- a/tests/test_release_process.py
+++ b/tests/test_release_process.py
@@ -50,6 +50,15 @@ def test_jenkins_build_creates_one_complete_candidate() -> None:
     assert "zhtw_checksums.txt" in script
 
 
+def test_nuget_package_builds_every_target_before_no_build_pack() -> None:
+    script = read("scripts/jenkins-build.sh")
+    restore = "dotnet restore sdk/dotnet/Zhtw.csproj"
+    build = "dotnet build sdk/dotnet/Zhtw.csproj -c Release --no-restore"
+    pack = 'dotnet pack sdk/dotnet/Zhtw.csproj -c Release --no-build --no-restore -o "$destination"'
+
+    assert script.index(restore) < script.index(build) < script.index(pack)
+
+
 def test_jenkins_release_is_idempotent_and_covers_every_target() -> None:
     script = read("scripts/jenkins-release.sh")
 


### PR DESCRIPTION
在使用 --no-build 封裝前，明確 restore 並 build NuGet 專案的所有 target framework。這可避免完整測試只留下 net8.0 輸出時，封裝找不到 netstandard2.0 DLL。\n\n驗證：\n- bash -n scripts/jenkins-build.sh\n- uv run ruff check tests/test_release_process.py\n- uv run pytest tests/test_release_process.py -q