### PR TITLE
修正 Jenkins Python 候選檔案集合

### DIFF
--- a/scripts/jenkins-build.sh
+++ b/scripts/jenkins-build.sh
@@ -78,6 +78,9 @@ package_python() {
     mkdir -p "$destination"
     rm -rf dist
     uv build --out-dir "$destination"
+    # uv creates this helper for output directories. It is not a distribution
+    # artifact and Jenkins' default archive excludes it, so never checksum it.
+    rm -f "$destination/.gitignore"
 }
 
 package_typescript() {
@@ -245,6 +248,7 @@ verify_candidate() {
 
     compgen -G "$OUTPUT_DIR/packages/python/zhtw-$RELEASE_VERSION.tar.gz" >/dev/null
     compgen -G "$OUTPUT_DIR/packages/python/zhtw-$RELEASE_VERSION-*.whl" >/dev/null
+    [ "$(find "$OUTPUT_DIR/packages/python" -maxdepth 1 -type f | wc -l | tr -d ' ')" = 2 ]
     local js_tgz wasm_tgz
     js_tgz="$(find "$OUTPUT_DIR/packages/npm" -maxdepth 1 -name "zhtw-js-$RELEASE_VERSION.tgz" -print -quit)"
     wasm_tgz="$(find "$OUTPUT_DIR/packages/npm" -maxdepth 1 -name "zhtw-wasm-$RELEASE_VERSION.tgz" -print -quit)"

--- a/tests/test_release_process.py
+++ b/tests/test_release_process.py
@@ -59,6 +59,13 @@ def test_nuget_package_builds_every_target_before_no_build_pack() -> None:
     assert script.index(restore) < script.index(build) < script.index(pack)
 
 
+def test_python_candidate_excludes_uv_output_helper() -> None:
+    script = read("scripts/jenkins-build.sh")
+
+    assert 'rm -f "$destination/.gitignore"' in script
+    assert 'find "$OUTPUT_DIR/packages/python" -maxdepth 1 -type f | wc -l' in script
+
+
 def test_jenkins_release_is_idempotent_and_covers_every_target() -> None:
     script = read("scripts/jenkins-release.sh")
 


### PR DESCRIPTION
移除 uv 在輸出目錄建立、但 Jenkins artifact 預設不封存的 .gitignore。候選驗證現在也要求 Python 目錄只有 source tarball 與 wheel，避免 checksum 含有非發布檔案。\n\n驗證：\n- bash -n scripts/jenkins-build.sh\n- uv run ruff check tests/test_release_process.py\n- uv run pytest tests/test_release_process.py -q