### PR TITLE
fix: keep release secret files in Jenkins workspace

### DIFF
--- a/scripts/jenkins-release.sh
+++ b/scripts/jenkins-release.sh
@@ -12,6 +12,19 @@ die() {
     exit 64
 }
 
+secret_runtime_root() {
+    local root="${ZHTW_SECRET_RUNTIME_ROOT:-}"
+    [ -n "$root" ] || die "ZHTW_SECRET_RUNTIME_ROOT is required for publication"
+    [ -n "${WORKSPACE:-}" ] || die "WORKSPACE is required for publication"
+    case "$root" in
+        "$WORKSPACE"/*) ;;
+        *) die "ZHTW_SECRET_RUNTIME_ROOT must stay inside WORKSPACE" ;;
+    esac
+    mkdir -p "$root"
+    chmod 700 "$root"
+    printf '%s\n' "$root"
+}
+
 require_common() {
     local name
     for name in SOURCE_SHA CANDIDATE_TREE_SHA RELEASE_VERSION VERSION_TAG; do
@@ -218,7 +231,7 @@ publish_pypi() {
 }
 
 publish_npm() {
-    local target="$1" package_name tarball temporary_config
+    local target="$1" package_name tarball temporary_config runtime_root
     require_common
     ensure_git_release
     [ -n "${NODE_AUTH_TOKEN:-}" ] || die "NODE_AUTH_TOKEN is required"
@@ -233,7 +246,8 @@ publish_npm() {
     fi
     tarball="$PAYLOAD_DIR/packages/npm/$package_name-$RELEASE_VERSION.tgz"
     [ -s "$tarball" ] || die "Missing npm tarball: $tarball"
-    temporary_config="$(mktemp)"
+    runtime_root="$(secret_runtime_root)"
+    temporary_config="$(mktemp "$runtime_root/npmrc.XXXXXX")"
     chmod 600 "$temporary_config"
     printf '%s\n' \
         'registry=https://registry.npmjs.org/' \
@@ -297,8 +311,9 @@ publish_maven() {
         return
     fi
 
-    local temporary layout bundle auth deployment_id attempt status
-    temporary="$(mktemp -d)"
+    local temporary layout bundle auth deployment_id attempt status runtime_root
+    runtime_root="$(secret_runtime_root)"
+    temporary="$(mktemp -d "$runtime_root/maven.XXXXXX")"
     trap "rm -rf -- '$temporary'" EXIT
     export GNUPGHOME="$temporary/gnupg"
     mkdir -m 700 "$GNUPGHOME"

--- a/tests/test_release_process.py
+++ b/tests/test_release_process.py
@@ -98,6 +98,16 @@ def test_release_secrets_are_not_command_line_arguments() -> None:
     assert "_authToken=${NODE_AUTH_TOKEN}" in script
 
 
+def test_release_secret_files_stay_in_disposable_workspace() -> None:
+    script = read("scripts/jenkins-release.sh")
+
+    assert "ZHTW_SECRET_RUNTIME_ROOT is required for publication" in script
+    assert "ZHTW_SECRET_RUNTIME_ROOT must stay inside WORKSPACE" in script
+    assert 'mktemp "$runtime_root/npmrc.XXXXXX"' in script
+    assert 'mktemp -d "$runtime_root/maven.XXXXXX"' in script
+    assert 'temporary_config="$(mktemp)"' not in script
+
+
 def test_release_verify_is_read_only_and_version_scoped() -> None:
     script = read("scripts/release-verify.sh")
 


### PR DESCRIPTION
## Summary
- require credential-derived npm and GPG files to stay inside the disposable Jenkins workspace
- reject host or external temporary locations
- add regression coverage

## Tests
- `uv run pytest tests/test_release_process.py -q`
- `bash -n scripts/jenkins-release.sh`