### PR TITLE
fix: run Jenkins benchmark with isolated container CLI

### DIFF
--- a/scripts/jenkins-verify.sh
+++ b/scripts/jenkins-verify.sh
@@ -11,6 +11,23 @@ die() {
     exit 64
 }
 
+prepare_container_cli() {
+    local runtime_root="$PWD/.jenkins-container-runtime"
+    mkdir -p "$runtime_root/bin" "$runtime_root/docker-config"
+    chmod 700 "$runtime_root" "$runtime_root/bin" "$runtime_root/docker-config"
+    printf '{"auths":{}}\n' > "$runtime_root/registry-auth.json"
+    chmod 600 "$runtime_root/registry-auth.json"
+    export DOCKER_CONFIG="$runtime_root/docker-config"
+    export REGISTRY_AUTH_FILE="$runtime_root/registry-auth.json"
+
+    if ! command -v docker >/dev/null 2>&1; then
+        command -v podman >/dev/null 2>&1 || die "Docker or Podman is required for competitor verification"
+        ln -sf "$(command -v podman)" "$runtime_root/bin/docker"
+        export PATH="$runtime_root/bin:$PATH"
+    fi
+    docker --version
+}
+
 verify_sdk_matrix() {
     local version environment java_home node_bin rust_toolchain go_bin
 
@@ -58,6 +75,7 @@ verify_sdk_matrix() {
 }
 
 verify_competitor_benchmark() {
+    prepare_container_cli
     uv sync --frozen --extra dev
     uv run python scripts/validate_competitor_environment.py
     make benchmark-competitor-probe

--- a/tests/test_release_process.py
+++ b/tests/test_release_process.py
@@ -108,6 +108,16 @@ def test_release_secret_files_stay_in_disposable_workspace() -> None:
     assert 'temporary_config="$(mktemp)"' not in script
 
 
+def test_jenkins_verify_uses_isolated_podman_compatible_cli() -> None:
+    script = read("scripts/jenkins-verify.sh")
+
+    assert "prepare_container_cli" in script
+    assert 'ln -sf "$(command -v podman)"' in script
+    assert 'export DOCKER_CONFIG="$runtime_root/docker-config"' in script
+    assert 'export REGISTRY_AUTH_FILE="$runtime_root/registry-auth.json"' in script
+    assert "printf '{\"auths\":{}}\\n'" in script
+
+
 def test_release_verify_is_read_only_and_version_scoped() -> None:
     script = read("scripts/release-verify.sh")
 


### PR DESCRIPTION
## Summary
- run the container-based benchmark through Docker or the installed Podman-compatible CLI
- isolate Docker and registry auth lookup inside the disposable workspace
- add regression coverage

## Tests
- `uv run pytest tests/test_release_process.py -q`
- `bash -n scripts/jenkins-verify.sh`