### PR TITLE
fix: isolate Podman cgroups in Jenkins service

### DIFF
--- a/scripts/jenkins-verify.sh
+++ b/scripts/jenkins-verify.sh
@@ -22,7 +22,9 @@ prepare_container_cli() {
 
     if ! command -v docker >/dev/null 2>&1; then
         command -v podman >/dev/null 2>&1 || die "Docker or Podman is required for competitor verification"
-        ln -sf "$(command -v podman)" "$runtime_root/bin/docker"
+        printf '#!/usr/bin/env bash\nexec %q --cgroup-manager=cgroupfs --events-backend=file "$@"\n' \
+            "$(command -v podman)" > "$runtime_root/bin/docker"
+        chmod 700 "$runtime_root/bin/docker"
         export PATH="$runtime_root/bin:$PATH"
     fi
     docker --version

--- a/tests/test_release_process.py
+++ b/tests/test_release_process.py
@@ -112,7 +112,8 @@ def test_jenkins_verify_uses_isolated_podman_compatible_cli() -> None:
     script = read("scripts/jenkins-verify.sh")
 
     assert "prepare_container_cli" in script
-    assert 'ln -sf "$(command -v podman)"' in script
+    assert "--cgroup-manager=cgroupfs --events-backend=file" in script
+    assert 'chmod 700 "$runtime_root/bin/docker"' in script
     assert 'export DOCKER_CONFIG="$runtime_root/docker-config"' in script
     assert 'export REGISTRY_AUTH_FILE="$runtime_root/registry-auth.json"' in script
     assert "printf '{\"auths\":{}}\\n'" in script


### PR DESCRIPTION
## Summary
- use a workspace-local Docker-compatible wrapper for Podman
- force cgroupfs and file event backends inside the Jenkins systemd service
- keep registry auth lookup isolated in the workspace

## Evidence
- minimal container command passed as `jenkins-agent` with the same cgroup and event options
- `uv run pytest tests/test_release_process.py -q`
- `bash -n scripts/jenkins-verify.sh`