### PR TITLE
docs: require Jenkins-managed runtime credentials

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -78,6 +78,11 @@ make version-check   # 任一檔案不一致就 exit 1
 - `make release` 與 `make release-dry` 會故意失敗；不是備援流程。
 - `zhtw/release` 預設 `PREVIEW`，不改任何外部狀態。只有使用者明確核准確切
   Jenkins build 後，才可用 `PUBLISH_ALL` 或 `RETRY_*`。
+- 所有 Git、通知與 registry 機密只能由 `zhtw/` folder-scoped Jenkins
+  Credentials 在需要的 stage 注入。Job 不得呼叫 1Password、讀取 agent 主機上的
+  私鑰／credential profile／session cache，或依賴互動式 shell。由 credential 產生的
+  npm、GPG、GitHub CLI 等暫存設定只能放在 disposable workspace，且每種結果都要清除。
+  1Password 只可由 operator 在 Job 外做 credential 建立或輪替，不是 runtime fallback。
 - Registry 接受版本後沒有 rollback；失敗時重跑同一 build 補齊，內容錯誤則升下一個
   patch，禁止刪除／移動 tag 或重用版號。
 - 每次操作前必讀 `.claude/rules/releasing.md` 與

--- a/tests/test_release_process.py
+++ b/tests/test_release_process.py
@@ -22,9 +22,13 @@ def read(path: str) -> str:
 
 def test_github_actions_are_not_a_ci_or_release_path() -> None:
     workflows = ROOT / ".github" / "workflows"
+    agent_rules = read("AGENTS.md")
 
     assert not workflows.exists() or not list(workflows.glob("*.yml"))
     assert not workflows.exists() or not list(workflows.glob("*.yaml"))
+    assert "folder-scoped Jenkins" in agent_rules
+    assert "1Password" in agent_rules
+    assert "disposable workspace" in agent_rules
 
 
 def test_direct_release_command_fails_closed() -> None:


### PR DESCRIPTION
## Summary
- add the Jenkins Credentials runtime rule to the project AGENTS.md
- forbid job-time 1Password and host-side secret fallbacks
- require credential-derived temporary files to stay in the disposable workspace
- add regression coverage

## Tests
- `uv run pytest tests/test_release_process.py -q`