### PR TITLE
強化 Jenkins 手動發版流程與成品驗證

### DIFF
--- a/.claude/rules/releasing.md
+++ b/.claude/rules/releasing.md
@@ -24,6 +24,8 @@
   verification receipt。`CREDENTIAL_PREFLIGHT` 會安全驗證所有發布 credential，
   但不建立 tag、Release 或 registry version；只有明確核准後才可 `PUBLISH_ALL`。
 - `make release` 與 `make release-dry` 會 fail-closed，提醒改用 Jenkins。
+- 三個 job 都只在準備發布時手動執行，不設每日、每週或 SCM 自動觸發。
+  `zhtw/build` 固定從 `main` 建立候選，不接受任意 branch。
 
 ## 標準流程
 
@@ -31,14 +33,15 @@
 
 ```bash
 jcli build zhtw/build \
-  -p BRANCH=main \
   -p VERSION_BUMP=patch
 ```
 
 `patch` 用於修正、`minor` 用於向下相容的新功能、`major` 用於 breaking
 change。Jenkins 會同步更新所有 SDK 版本、提升 CHANGELOG `[Unreleased]`、跑完整
-release gate，阻擋 open medium 以上 Dependabot 警示與即將到期的 npm token，並建出
-PyPI、npm x2、crate、NuGet、Maven 與五種 Go binary。
+release gate，阻擋 open medium 以上 Dependabot 警示與即將到期的 npm token；它也會
+執行 Python、npm、Rust、Go、.NET、Maven 的相依套件安全檢查。完成後建出 PyPI、
+npm x2、crate、NuGet、Maven 與五種 Go binary，並從封存成品逐一執行 consumer
+smoke test。候選會記錄 Jenkins pipeline 與完整 toolchain 版本證據。
 
 ### 2. 驗證同一份候選
 
@@ -48,8 +51,9 @@ jcli build zhtw/verify \
   -p VERIFY_SUITE=all
 ```
 
-只有 `all` 會產生可供發布的 receipt。`sdk-matrix` 與 `competitor-benchmark` 可以單獨
-診斷，但不能解除 release gate。
+只有 `all` 會產生可供發布的 receipt。receipt 也會繫結驗證 pipeline 與驗證證據
+checksum。`sdk-matrix` 與 `competitor-benchmark` 可以單獨診斷，但不能解除
+release gate。
 
 ### 3. 唯讀預演
 
@@ -61,9 +65,9 @@ jcli build zhtw/release \
   -p SKIP_CONFIRMATION=false
 ```
 
-預演會先驗證 receipt 與候選的 checksum、base SHA、base tree、candidate tree、版本
-完全相同，再檢查 main 前進關係與既有 tag。它不繫結 registry credential，也不改
-Git 或外部服務。
+預演會先驗證 receipt、候選、toolchain 與驗證證據的 checksum，以及 base SHA、base
+tree、candidate tree、版本完全相同，再檢查 main 前進關係與既有 tag。它不繫結
+registry credential，也不改 Git 或外部服務。
 
 ### 4. 安全驗證所有 credential
 
@@ -86,14 +90,20 @@ jcli build zhtw/release \
   -p BUILD_NUMBER=<同一個-zhtw-build> \
   -p VERIFY_BUILD_NUMBER=<同一個-zhtw-verify> \
   -p RELEASE_ACTION=PUBLISH_ALL \
+  -p APPROVAL_REFERENCE='<目前對話或變更單參照>' \
   -p SKIP_CONFIRMATION=true
 ```
 
 正常順序是：雙 tag 與 GitHub Release → PyPI → npm `zhtw-js` → npm
 `zhtw-wasm` → crates.io → NuGet → Maven Central → Homebrew → 完整公開驗證。
 
-`SKIP_CONFIRMATION=true` 只代表使用者已在目前對話核准這組確切 build 與 verify，
-不會略過 receipt、來源、checksum、tag 或 registry 驗證。
+`PUBLISH_ALL` 只接受 24 小時內完成相依套件閘門、且 7 天內完成 `all` 驗證的候選。
+開始任何會改變外部狀態的 action 前，Jenkins 會把選定的 build、verify 與本次 release
+標記為永久保留，避免 recovery 證據被一般保留政策清除。
+
+`SKIP_CONFIRMATION=true` 只代表使用者已在目前對話核准這組確切 build 與 verify；此時
+`APPROVAL_REFERENCE` 必填。它不會略過 receipt、來源、checksum、tag、GitHub Release
+notes、候選 tree 或 registry 驗證。
 
 所有長時間 job 都要 detached 啟動，再用 Jenkins UI 或 API 監看回傳的 build number；
 不可使用 attached `jcli -s -v`。CLI 連線中斷曾經直接中止還在執行的 Jenkins build。
@@ -113,11 +123,14 @@ jcli build zhtw/release \
   -p BUILD_NUMBER=<同一個-zhtw-build> \
   -p VERIFY_BUILD_NUMBER=<同一個-zhtw-verify> \
   -p RELEASE_ACTION=RESUME_ALL \
+  -p APPROVAL_REFERENCE='<目前對話或 incident 參照>' \
   -p SKIP_CONFIRMATION=true
 ```
 
 Maven 上傳後會立即封存 deployment ID。若狀態查詢斷線，使用
 `RESUME_ALL` 加上該 ID 續查既有 deployment，不可建立第二次 upload。
+Recovery action 可以使用超過上述 freshness 期限的同一份封存候選，因為它的目的只
+是補完已開始的不可逆發布；SHA、tree、receipt 與 checksum 仍必須完全相符。
 
 可用的修復動作：`RETRY_GIT`、`RETRY_PYPI`、`RETRY_NPM_JS`、
 `RETRY_NPM_WASM`、`RETRY_CRATES`、`RETRY_NUGET`、`RETRY_MAVEN`、

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -76,6 +76,8 @@ make version-check   # 任一檔案不一致就 exit 1
 - 禁止恢復 `.github/workflows`、執行 `gh workflow run`、本機建立 release tag，或
   直接對 PyPI/npm/crates/NuGet/Maven publish。
 - `make release` 與 `make release-dry` 會故意失敗；不是備援流程。
+- `zhtw/build`、`zhtw/verify`、`zhtw/release` 都只在準備發版時手動執行；禁止每日、
+  每週或 SCM 自動 trigger。build 固定從 `main` 建立候選，不接受任意 branch。
 - `zhtw/verify` 必須選定一個成功的 main `zhtw/build`，並以 `VERIFY_SUITE=all`
   產生 verification receipt；`zhtw/release` 只接受 SHA、tree、版本與 checksum
   都和候選完全相同的成功 receipt。
@@ -83,8 +85,12 @@ make version-check   # 任一檔案不一致就 exit 1
   Jenkins build 與 verify build 後，才可用 `PUBLISH_ALL` 或 `RETRY_*`。
 - `CREDENTIAL_PREFLIGHT` 是不發布的安全驗證；正式發布與每個 retry 會在確認閘門前
   重新執行該目標需要的 credential preflight。預檢成功不等於核准正式發布。
-- `zhtw/build` 必須阻擋 open medium/high/critical Dependabot 警示，並封存去敏後證據；
-  npm token 到期日少於 14 天也必須阻擋候選。
+- `zhtw/build` 必須阻擋 open medium/high/critical Dependabot 警示與 Python、npm、
+  Rust、Go、.NET、Maven 本機相依套件檢查失敗，並封存去敏後證據；npm token 到期日
+  少於 14 天也必須阻擋候選。
+- `PUBLISH_ALL` 只接受 24 小時內完成 dependency gate、7 天內完成 `all` verify 的
+  候選。任何 mutating action 都必須永久保留 build/verify/release 證據；略過 Jenkins
+  UI 確認時必須留下 `APPROVAL_REFERENCE`。Recovery 可續用過期但完全相同的候選。
 - 所有 Git、通知與 registry 機密只能由 `zhtw/` folder-scoped Jenkins
   Credentials 在需要的 stage 注入。Job 不得呼叫 1Password、讀取 agent 主機上的
   私鑰／credential profile／session cache，或依賴互動式 shell。由 credential 產生的

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- zhtw Jenkins build、verify、release 改為只在準備發版時手動執行；移除每日與每週
+  排程，build 固定從 `main` 建立候選，不再接受任意 branch。
+- 候選新增 Rust、Go、.NET、Maven 相依套件安全閘門、完整 toolchain 證據，以及從
+  封存 Python、npm、WASM、Rust、NuGet、Maven、Go 成品執行的 consumer smoke test。
+- verification receipt 與 release receipt 新增 Jenkins pipeline SHA、驗證證據
+  checksum、核准參照、freshness、永久保留與最終公開驗證紀錄。
+
+### Fixed
+- 發布中斷後會保留原 build、verify 與 release，並從第一個未完成 registry 接續；
+  已完成且內容相同的 registry 不會重複上傳。
+- GitHub Release 現在會嚴格驗證 tag、標題、notes、Latest、draft/prerelease 狀態與
+  候選 tree，Maven 公開驗證也會確認每個主要 artifact 的簽章存在。
+- Dependabot read token 在 checkout 專案程式碼前完成 API 讀取並立即解除綁定，且
+  必須和 GitHub Release write token 使用不同的 1Password item 與不同 token。
+
 ## [4.4.5] - 2026-08-10
 
 ### Fixed

--- a/docs/releases/RELEASE-CHECKLIST.md
+++ b/docs/releases/RELEASE-CHECKLIST.md
@@ -12,8 +12,10 @@
 
 ## 候選與唯讀預演
 
+三個 zhtw job 都是手動、發版時才執行；不應存在每日、每週或 SCM trigger。
+
 ```bash
-jcli build zhtw/build -p BRANCH=main -p VERSION_BUMP=patch
+jcli build zhtw/build -p VERSION_BUMP=patch
 jcli build zhtw/verify \
   -p BUILD_NUMBER=<成功-build> -p VERIFY_SUITE=all
 jcli build zhtw/release \
@@ -22,11 +24,15 @@ jcli build zhtw/release \
   -p SKIP_CONFIRMATION=false
 ```
 
-- [ ] build 的 lint、release gate、全部套件建置與 checksum 都成功。
-- [ ] Dependabot 沒有 open medium/high/critical 警示，npm token 距離到期超過 14 天。
+- [ ] build 固定 checkout `main`，沒有可選 branch 或自動排程。
+- [ ] build 的 lint、release gate、全部套件建置、consumer smoke test 與 checksum 都成功。
+- [ ] Dependabot 沒有 open medium/high/critical 警示，npm token 距離到期超過 14 天；
+      Python、npm、Rust、Go、.NET 與 Maven 的本機安全檢查全部通過。
 - [ ] manifest 的 base SHA、base tree、candidate tree、release/build version 正確。
+- [ ] manifest schema、build pipeline SHA 與 toolchain 證據 checksum 正確。
 - [ ] verify 使用同一 build、`VERIFY_SUITE=all`，並封存 release-eligible receipt。
-- [ ] receipt 的 build、SHA、tree、版本與 manifest/checksum hash 都和候選完全相同。
+- [ ] receipt 的 build、SHA、tree、版本、pipeline SHA、manifest/checksum 與驗證證據 hash
+      都和候選完全相同。
 - [ ] preview 使用同一組 build/verify，且沒有新增 tag、Release 或 registry version。
 - [ ] 所有 job 都 detached 啟動並用 Jenkins UI/API 監看，沒有使用 `jcli -s -v`。
 
@@ -48,11 +54,15 @@ jcli build zhtw/release \
 jcli build zhtw/release \
   -p BUILD_NUMBER=<同一-build> -p VERIFY_BUILD_NUMBER=<同一-verify> \
   -p RELEASE_ACTION=PUBLISH_ALL \
+  -p APPROVAL_REFERENCE='<目前對話或變更單參照>' \
   -p SKIP_CONFIRMATION=true
 ```
 
+- [ ] 相依套件閘門在 24 小時內、`all` 驗證在 7 天內完成。
+- [ ] Jenkins 已將 build、verify 與本次 release 標記永久保留。
 - [ ] 雙 tag 指向同一個 candidate release commit。
-- [ ] GitHub root/Go Release 與五個 Go 檔案、checksum 完整。
+- [ ] GitHub root/Go Release 的 tag、標題、notes、draft/prerelease 狀態完全正確；root 是
+      Latest，且五個 Go 檔案與 checksum 完整。
 - [ ] PyPI、npm x2、crates.io、NuGet、Maven Central、Go proxy 都可見。
 - [ ] Homebrew formula 指向同一版本 PyPI sdist 與正確 SHA-256。
 - [ ] Jenkins 最後 12/12 公開檢查通過。
@@ -66,3 +76,5 @@ jcli build zhtw/release \
 - [ ] 若內容本身有錯，修正後升下一個 patch，不重用版號。
 - [ ] Maven 若已有 deployment ID，使用 `RESUME_ALL` 加該 ID 續查，不重複上傳。
 - [ ] 單項 `RETRY_*` 完成後仍執行 `RESUME_ALL`，補完後續 registry 與最終驗證。
+- [ ] Recovery action 使用同一份已保留候選；即使超過 freshness 期限，也沒有重建或
+      重用版號，且提供新的 `APPROVAL_REFERENCE`。

--- a/scripts/jenkins-build.sh
+++ b/scripts/jenkins-build.sh
@@ -320,7 +320,7 @@ verify_candidate() {
 
 smoke_candidate_packages() {
     local temporary wheel js_tgz wasm_tgz crate nuget jar pom java_classpath
-    local go_archive go_binary
+    local go_archive go_binary dotnet_major dotnet_framework
     temporary="$(mktemp -d "$WORKSPACE/candidate-smoke.XXXXXX")"
     trap 'rm -rf -- "$temporary"' RETURN
 
@@ -354,7 +354,12 @@ smoke_candidate_packages() {
         --manifest-path "$temporary/crate/zhtw-$RELEASE_VERSION/Cargo.toml" --release
 
     nuget="$OUTPUT_DIR/packages/nuget/Zhtw.$RELEASE_VERSION.nupkg"
-    dotnet new console --framework net8.0 --output "$temporary/dotnet" --no-restore >/dev/null
+    dotnet_major="$(dotnet --version | cut -d. -f1)"
+    [[ "$dotnet_major" =~ ^[0-9]+$ ]] && [ "$dotnet_major" -ge 8 ] || \
+        die "Consumer smoke test requires .NET SDK 8 or newer"
+    dotnet_framework="net${dotnet_major}.0"
+    dotnet new console --framework "$dotnet_framework" \
+        --output "$temporary/dotnet" --no-restore >/dev/null
     dotnet add "$temporary/dotnet" package Zhtw --version "$RELEASE_VERSION" \
         --no-restore >/dev/null
     dotnet restore "$temporary/dotnet" \
@@ -363,7 +368,7 @@ smoke_candidate_packages() {
         'using Zhtw;' \
         'if (ZhtwConvert.Convert("这个软件") != "這個軟體") Environment.Exit(1);' \
         > "$temporary/dotnet/Program.cs"
-    dotnet run --project "$temporary/dotnet" --framework net8.0 --no-restore
+    dotnet run --project "$temporary/dotnet" --framework "$dotnet_framework" --no-restore
 
     jar="$OUTPUT_DIR/packages/maven/zhtw-$RELEASE_VERSION.jar"
     pom="$OUTPUT_DIR/packages/maven/zhtw-$RELEASE_VERSION.pom"

--- a/scripts/jenkins-build.sh
+++ b/scripts/jenkins-build.sh
@@ -37,7 +37,7 @@ require_env() {
 
 require_tools() {
     local tool
-    for tool in uv python3 java mvn node pnpm cargo rustc go dotnet wasm-pack jq zip unzip git sha256sum; do
+    for tool in uv python3 java javac mvn node npm pnpm cargo rustc go dotnet wasm-pack jq zip unzip git sha256sum; do
         command -v "$tool" >/dev/null 2>&1 || die "Required tool is missing: $tool"
     done
 }
@@ -165,7 +165,7 @@ package_crate() {
     local destination="$1"
     mkdir -p "$destination"
     rm -f sdk/rust/target/package/zhtw-*.crate
-    cargo package --manifest-path sdk/rust/zhtw/Cargo.toml --allow-dirty --no-verify
+    cargo package --manifest-path sdk/rust/zhtw/Cargo.toml --allow-dirty
     cp sdk/rust/target/package/zhtw-"$RELEASE_VERSION".crate "$destination/"
 }
 
@@ -261,6 +261,8 @@ package_candidate() {
     package_maven "$OUTPUT_DIR/packages/maven"
     package_go "$OUTPUT_DIR/packages/go"
 
+    ./scripts/write-toolchain-evidence.sh "$OUTPUT_DIR/metadata/toolchain.properties"
+
     git diff --check
     git diff --binary HEAD -- . > "$OUTPUT_DIR/candidate/release.patch"
     [ -s "$OUTPUT_DIR/candidate/release.patch" ] || die "Candidate patch is empty"
@@ -312,6 +314,93 @@ verify_candidate() {
     [ -s "$OUTPUT_DIR/packages/maven/zhtw-$RELEASE_VERSION.pom" ]
     [ "$(find "$OUTPUT_DIR/packages/go" -maxdepth 1 \( -name '*.tar.gz' -o -name '*.zip' \) | wc -l | tr -d ' ')" = 5 ]
     (cd "$OUTPUT_DIR/packages/go" && sha256sum -c zhtw_checksums.txt)
+    [ -s "$OUTPUT_DIR/metadata/toolchain.properties" ]
+    smoke_candidate_packages
+}
+
+smoke_candidate_packages() {
+    local temporary wheel js_tgz wasm_tgz crate nuget jar pom java_classpath
+    local go_archive go_binary
+    temporary="$(mktemp -d "$WORKSPACE/candidate-smoke.XXXXXX")"
+    trap 'rm -rf -- "$temporary"' RETURN
+
+    wheel="$(find "$OUTPUT_DIR/packages/python" -maxdepth 1 -name 'zhtw-*.whl' -print -quit)"
+    [ -s "$wheel" ] || die "Python wheel is missing for consumer smoke test"
+    uv venv --python 3.13 "$temporary/python"
+    uv pip install --python "$temporary/python/bin/python" "$wheel"
+    "$temporary/python/bin/python" -c \
+        'from zhtw import convert; assert convert("这个软件") == "這個軟體"'
+
+    js_tgz="$OUTPUT_DIR/packages/npm/zhtw-js-$RELEASE_VERSION.tgz"
+    wasm_tgz="$OUTPUT_DIR/packages/npm/zhtw-wasm-$RELEASE_VERSION.tgz"
+    mkdir -p "$temporary/node-js" "$temporary/node-wasm"
+    (
+        cd "$temporary/node-js"
+        npm install --ignore-scripts --no-audit --no-fund "$js_tgz" >/dev/null
+        node --input-type=module -e \
+            'import { convert } from "zhtw-js"; if (convert("这个软件") !== "這個軟體") process.exit(1)'
+    )
+    (
+        cd "$temporary/node-wasm"
+        npm install --ignore-scripts --no-audit --no-fund "$wasm_tgz" >/dev/null
+        node --experimental-wasm-modules --no-warnings --input-type=module -e \
+            'import { convert } from "zhtw-wasm"; if (convert("这个软件") !== "這個軟體") process.exit(1)'
+    )
+
+    crate="$OUTPUT_DIR/packages/crates/zhtw-$RELEASE_VERSION.crate"
+    mkdir -p "$temporary/crate"
+    tar -xzf "$crate" -C "$temporary/crate"
+    cargo +stable test \
+        --manifest-path "$temporary/crate/zhtw-$RELEASE_VERSION/Cargo.toml" --release
+
+    nuget="$OUTPUT_DIR/packages/nuget/Zhtw.$RELEASE_VERSION.nupkg"
+    dotnet new console --framework net8.0 --output "$temporary/dotnet" --no-restore >/dev/null
+    dotnet add "$temporary/dotnet" package Zhtw --version "$RELEASE_VERSION" \
+        --no-restore >/dev/null
+    dotnet restore "$temporary/dotnet" \
+        --source "$OUTPUT_DIR/packages/nuget" >/dev/null
+    printf '%s\n' \
+        'using Zhtw;' \
+        'if (ZhtwConvert.Convert("这个软件") != "這個軟體") Environment.Exit(1);' \
+        > "$temporary/dotnet/Program.cs"
+    dotnet run --project "$temporary/dotnet" --framework net8.0 --no-restore
+
+    jar="$OUTPUT_DIR/packages/maven/zhtw-$RELEASE_VERSION.jar"
+    pom="$OUTPUT_DIR/packages/maven/zhtw-$RELEASE_VERSION.pom"
+    mkdir -p "$temporary/java/src" "$temporary/java/classes" "$temporary/java/repository"
+    mvn --batch-mode --no-transfer-progress \
+        -Dmaven.repo.local="$temporary/java/repository" \
+        org.apache.maven.plugins:maven-install-plugin:3.1.4:install-file \
+        -Dfile="$jar" -DpomFile="$pom"
+    cp "$pom" "$temporary/java/pom.xml"
+    mvn --batch-mode --no-transfer-progress \
+        -Dmaven.repo.local="$temporary/java/repository" \
+        -f "$temporary/java/pom.xml" \
+        org.apache.maven.plugins:maven-dependency-plugin:3.8.1:build-classpath \
+        -Dmdep.outputFile="$temporary/java/classpath"
+    java_classpath="$jar:$(cat "$temporary/java/classpath")"
+    printf '%s\n' \
+        'import com.rajatim.zhtw.ZhtwConverter;' \
+        'public final class Smoke {' \
+        '  public static void main(String[] args) {' \
+        '    if (!ZhtwConverter.getDefault().convert("这个软件").equals("這個軟體")) System.exit(1);' \
+        '  }' \
+        '}' > "$temporary/java/src/Smoke.java"
+    javac -encoding UTF-8 -cp "$java_classpath" -d "$temporary/java/classes" \
+        "$temporary/java/src/Smoke.java"
+    java -cp "$java_classpath:$temporary/java/classes" Smoke
+
+    go_archive="$OUTPUT_DIR/packages/go/zhtw-linux-amd64.tar.gz"
+    mkdir -p "$temporary/go"
+    tar -xzf "$go_archive" -C "$temporary/go"
+    go_binary="$temporary/go/zhtw-linux-amd64"
+    [ -x "$go_binary" ] || die "Linux Go CLI is missing from its archive"
+    "$go_binary" version | grep -F "zhtw $RELEASE_VERSION " >/dev/null
+    [ "$("$go_binary" convert '这个软件')" = '這個軟體' ] || die "Go CLI consumer smoke failed"
+
+    rm -rf -- "$temporary"
+    trap - RETURN
+    printf 'All archived package consumer smoke tests passed\n'
 }
 
 require_jenkins_build_runtime

--- a/scripts/jenkins-build.sh
+++ b/scripts/jenkins-build.sh
@@ -320,7 +320,7 @@ verify_candidate() {
 
 smoke_candidate_packages() {
     local temporary wheel js_tgz wasm_tgz crate nuget jar pom java_classpath
-    local go_archive go_binary dotnet_major dotnet_framework
+    local go_archive go_binary go_platform dotnet_major dotnet_framework
     temporary="$(mktemp -d "$WORKSPACE/candidate-smoke.XXXXXX")"
     trap 'rm -rf -- "$temporary"' RETURN
 
@@ -395,11 +395,18 @@ smoke_candidate_packages() {
         "$temporary/java/src/Smoke.java"
     java -cp "$java_classpath:$temporary/java/classes" Smoke
 
-    go_archive="$OUTPUT_DIR/packages/go/zhtw-linux-amd64.tar.gz"
+    case "$(uname -s)-$(uname -m)" in
+        Linux-x86_64) go_platform="linux-amd64" ;;
+        Linux-aarch64|Linux-arm64) go_platform="linux-arm64" ;;
+        Darwin-x86_64) go_platform="darwin-amd64" ;;
+        Darwin-arm64) go_platform="darwin-arm64" ;;
+        *) die "No native Go CLI archive for $(uname -s)-$(uname -m)" ;;
+    esac
+    go_archive="$OUTPUT_DIR/packages/go/zhtw-$go_platform.tar.gz"
     mkdir -p "$temporary/go"
     tar -xzf "$go_archive" -C "$temporary/go"
-    go_binary="$temporary/go/zhtw-linux-amd64"
-    [ -x "$go_binary" ] || die "Linux Go CLI is missing from its archive"
+    go_binary="$temporary/go/zhtw-$go_platform"
+    [ -x "$go_binary" ] || die "Native Go CLI is missing from its archive"
     "$go_binary" version | grep -F "zhtw $RELEASE_VERSION " >/dev/null
     [ "$("$go_binary" convert '这个软件')" = '這個軟體' ] || die "Go CLI consumer smoke failed"
 

--- a/scripts/jenkins-release.sh
+++ b/scripts/jenkins-release.sh
@@ -151,6 +151,23 @@ ensure_release_asset() {
     fi
 }
 
+verify_github_release_metadata() {
+    local tag="$1" expected_title="$2" expected_notes="$3" release_json
+    local actual_notes expected_notes_text
+    release_json="$(gh release view "$tag" --json tagName,name,body,isDraft,isPrerelease)" || \
+        die "GitHub Release metadata is unavailable: $tag"
+    jq -e \
+        --arg tag "$tag" \
+        --arg title "$expected_title" \
+        '.tagName == $tag and .name == $title and .isDraft == false and .isPrerelease == false' \
+        <<< "$release_json" >/dev/null || \
+        die "Existing GitHub Release metadata differs: $tag"
+    actual_notes="$(jq -r '.body // ""' <<< "$release_json")"
+    expected_notes_text="$(cat "$expected_notes")"
+    [ "$actual_notes" = "$expected_notes_text" ] || \
+        die "Existing GitHub Release notes differ: $tag"
+}
+
 publish_git() {
     require_common
     [ -n "${GH_TOKEN:-}" ] || die "GH_TOKEN is required"
@@ -206,10 +223,21 @@ publish_git() {
         gh release create "$VERSION_TAG" --title "$VERSION_TAG" \
             --notes-file "$PAYLOAD_DIR/candidate/release-notes.md" --latest
     fi
+    verify_github_release_metadata \
+        "$VERSION_TAG" "$VERSION_TAG" "$PAYLOAD_DIR/candidate/release-notes.md"
+    [ "$(gh api repos/rajatim/zhtw/releases/latest --jq '.tag_name')" = "$VERSION_TAG" ] || \
+        die "Root GitHub Release is not marked latest: $VERSION_TAG"
+
+    local go_release_notes
+    go_release_notes="$(mktemp "$WORKSPACE/go-release-notes.XXXXXX")"
+    printf 'Jenkins-built Go CLI for %s.\n' "$VERSION_TAG" > "$go_release_notes"
     if ! gh release view "sdk/go/$VERSION_TAG" >/dev/null 2>&1; then
         gh release create "sdk/go/$VERSION_TAG" --title "Go CLI $VERSION_TAG" \
-            --notes "Jenkins-built Go CLI for $VERSION_TAG." --latest=false
+            --notes-file "$go_release_notes" --latest=false
     fi
+    verify_github_release_metadata \
+        "sdk/go/$VERSION_TAG" "Go CLI $VERSION_TAG" "$go_release_notes"
+    rm -f -- "$go_release_notes"
     local asset
     for asset in "$PAYLOAD_DIR"/packages/go/*.tar.gz \
                  "$PAYLOAD_DIR"/packages/go/*.zip \

--- a/scripts/jenkins-verify.sh
+++ b/scripts/jenkins-verify.sh
@@ -4,7 +4,10 @@ set -euo pipefail
 
 SUITE="${1:-all}"
 TOOLS_ROOT="${ZHTW_TOOLS_ROOT:-$HOME/.local/share/zhtw-tools}"
-export PATH="$HOME/.cargo/bin:$TOOLS_ROOT/dotnet:$TOOLS_ROOT/go/bin:$TOOLS_ROOT/wasm-pack:$PATH"
+export PATH="$HOME/.cargo/bin:$TOOLS_ROOT/security/bin:$TOOLS_ROOT/dotnet:$TOOLS_ROOT/go/bin:$TOOLS_ROOT/wasm-pack:$PATH"
+export UV_PYTHON=3.13
+export UV_PYTHON_PREFERENCE=only-managed
+EVIDENCE_DIR="${ZHTW_VERIFY_EVIDENCE_DIR:-${WORKSPACE:-}/verification-evidence}"
 
 die() {
     printf 'ERROR: %s\n' "$*" >&2
@@ -17,21 +20,43 @@ require_jenkins_verify_runtime() {
     [ -n "${JENKINS_URL:-}" ] || die "JENKINS_URL is required"
     [ -n "${BUILD_TAG:-}" ] || die "BUILD_TAG is required"
     [ -n "${WORKSPACE:-}" ] || die "WORKSPACE is required"
+    case "$EVIDENCE_DIR" in
+        "$WORKSPACE"/*) ;;
+        *) die "ZHTW_VERIFY_EVIDENCE_DIR must stay inside WORKSPACE" ;;
+    esac
+    [[ "${RELEASE_DATE:-}" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}$ ]] || \
+        die "RELEASE_DATE must be YYYY-MM-DD"
 }
 
 prepare_container_cli() {
     local runtime_root="$PWD/.jenkins-container-runtime"
+    local podman_socket="/home/jenkins-agent/.local/run/podman.sock"
     mkdir -p "$runtime_root/bin" "$runtime_root/docker-config"
     chmod 700 "$runtime_root" "$runtime_root/bin" "$runtime_root/docker-config"
     printf '{"auths":{}}\n' > "$runtime_root/registry-auth.json"
     chmod 600 "$runtime_root/registry-auth.json"
     export DOCKER_CONFIG="$runtime_root/docker-config"
     export REGISTRY_AUTH_FILE="$runtime_root/registry-auth.json"
+    export TESTCONTAINERS_RYUK_DISABLED=true
 
-    if ! command -v docker >/dev/null 2>&1; then
+    if [ -S "$podman_socket" ]; then
         command -v podman >/dev/null 2>&1 || die "Docker or Podman is required for competitor verification"
-        printf '#!/usr/bin/env bash\nexec %q --cgroup-manager=cgroupfs --events-backend=file "$@"\n' \
-            "$(command -v podman)" > "$runtime_root/bin/docker"
+        export DOCKER_HOST="unix://$podman_socket"
+        printf '#!/usr/bin/env bash\nexec %q --remote --url %q "$@"\n' \
+            "$(command -v podman)" "$DOCKER_HOST" > "$runtime_root/bin/docker"
+        chmod 700 "$runtime_root/bin/docker"
+        export PATH="$runtime_root/bin:$PATH"
+    elif ! command -v docker >/dev/null 2>&1; then
+        local xdg_root="$runtime_root/xdg"
+        local storage_root="$runtime_root/storage"
+        local storage_runroot="$runtime_root/runroot"
+        local podman_tmp="$runtime_root/tmp"
+        command -v podman >/dev/null 2>&1 || die "Docker or Podman is required for competitor verification"
+        mkdir -p "$xdg_root" "$storage_root" "$storage_runroot" "$podman_tmp"
+        chmod 700 "$xdg_root" "$storage_root" "$storage_runroot" "$podman_tmp"
+        printf '#!/usr/bin/env bash\nexport XDG_RUNTIME_DIR=%q\nexec %q --root %q --runroot %q --tmpdir %q --cgroup-manager=cgroupfs --events-backend=file "$@"\n' \
+            "$xdg_root" "$(command -v podman)" "$storage_root" "$storage_runroot" "$podman_tmp" \
+            > "$runtime_root/bin/docker"
         chmod 700 "$runtime_root/bin/docker"
         export PATH="$runtime_root/bin:$PATH"
     fi
@@ -39,14 +64,28 @@ prepare_container_cli() {
 }
 
 verify_sdk_matrix() {
-    local version environment java_home node_bin rust_toolchain go_bin
+    local version environment java_home node_bin rust_toolchain go_bin index failed
+    local -a python_pids=() python_versions=()
 
     for version in 3.10 3.11 3.12 3.13; do
         environment="$PWD/.venv-python-${version/./}"
-        UV_PROJECT_ENVIRONMENT="$environment" uv sync --python "$version" --frozen --extra dev
-        UV_PROJECT_ENVIRONMENT="$environment" uv run ruff check .
-        UV_PROJECT_ENVIRONMENT="$environment" uv run pytest tests/ -q
+        (
+            UV_PROJECT_ENVIRONMENT="$environment" uv sync --python "$version" --frozen --extra dev
+            UV_PROJECT_ENVIRONMENT="$environment" uv run pytest tests/ -q
+        ) > "$EVIDENCE_DIR/python-$version.log" 2>&1 &
+        python_pids+=("$!")
+        python_versions+=("$version")
     done
+    failed=0
+    for index in "${!python_pids[@]}"; do
+        if ! wait "${python_pids[$index]}"; then
+            printf 'Python %s compatibility test failed\n' "${python_versions[$index]}" >&2
+            failed=1
+        fi
+        cat "$EVIDENCE_DIR/python-${python_versions[$index]}.log"
+    done
+    [ "$failed" -eq 0 ] || die "One or more Python compatibility tests failed"
+    UV_PROJECT_ENVIRONMENT="$PWD/.venv-python-313" uv run ruff check .
 
     for version in 11 17 21; do
         java_home="$TOOLS_ROOT/jdks/$version"
@@ -85,21 +124,23 @@ verify_sdk_matrix() {
 }
 
 verify_competitor_benchmark() {
+    local benchmark_dir="$EVIDENCE_DIR/benchmarks"
+    mkdir -p "$benchmark_dir"
     prepare_container_cli
     uv sync --frozen --extra dev
     uv run python scripts/validate_competitor_environment.py
     make benchmark-competitor-probe
     uv run pytest tests/test_competitor_environment.py -q
     uv run python scripts/run_ud_gsd_benchmark.py \
-        --generated-date 2026-07-31 --output-prefix /tmp/zhtw-jenkins-ud-gsd
+        --generated-date "$RELEASE_DATE" --output-prefix "$benchmark_dir/ud-gsd"
     uv run python scripts/run_naer_terms_benchmark.py \
-        --generated-date 2026-07-31 --output-prefix /tmp/zhtw-jenkins-naer-terms
+        --generated-date "$RELEASE_DATE" --output-prefix "$benchmark_dir/naer-terms"
     uv run python scripts/validate_benchmark_non_regression.py \
         docs/reports/ud-gsd-benchmark-2026-07-31.json \
-        /tmp/zhtw-jenkins-ud-gsd.json
+        "$benchmark_dir/ud-gsd.json"
     uv run python scripts/validate_benchmark_non_regression.py \
         docs/reports/naer-terms-benchmark-2026-07-31.json \
-        /tmp/zhtw-jenkins-naer-terms.json
+        "$benchmark_dir/naer-terms.json"
     make benchmark-paired-import-check
 
     local image benchmark_id
@@ -110,24 +151,26 @@ verify_competitor_benchmark() {
             --manifest "benchmarks/accuracy/manifests/$benchmark_id.json" \
             --engines zhtw,opencc-s2twp,zhconv-zh-tw \
             --container-image "$image" \
-            --generated-date 2026-07-31 \
-            --output-prefix "/tmp/zhtw-jenkins-$benchmark_id"
+            --generated-date "$RELEASE_DATE" \
+            --output-prefix "$benchmark_dir/$benchmark_id"
         uv run python scripts/validate_benchmark_non_regression.py \
             "docs/reports/$benchmark_id-benchmark-2026-07-31.json" \
-            "/tmp/zhtw-jenkins-$benchmark_id.json"
+            "$benchmark_dir/$benchmark_id.json"
     done
 
     uv run python scripts/reproduce_public_benchmarks.py \
         --operator jenkins \
         --organization rajatim/zhtw \
         --local-smoke-test \
-        --output /tmp/zhtw-public-benchmark-attestation.json
+        --output "$benchmark_dir/public-benchmark-attestation.json"
     uv run python scripts/validate_public_benchmark_attestation.py \
         --allow-local-smoke-test \
-        /tmp/zhtw-public-benchmark-attestation.json
+        "$benchmark_dir/public-benchmark-attestation.json"
 }
 
 require_jenkins_verify_runtime
+mkdir -p "$EVIDENCE_DIR"
+chmod 700 "$EVIDENCE_DIR"
 
 case "$SUITE" in
     sdk-matrix) verify_sdk_matrix ;;
@@ -138,3 +181,12 @@ case "$SUITE" in
         ;;
     *) die "Usage: scripts/jenkins-verify.sh {sdk-matrix|competitor-benchmark|all}" ;;
 esac
+
+./scripts/write-toolchain-evidence.sh "$EVIDENCE_DIR/toolchain.properties"
+(
+    cd "$EVIDENCE_DIR"
+    find . -type f ! -name SHA256SUMS -print0 | LC_ALL=C sort -z | \
+        xargs -0 -r sha256sum > SHA256SUMS
+    test -s SHA256SUMS
+    sha256sum -c SHA256SUMS
+)

--- a/scripts/release-verify.sh
+++ b/scripts/release-verify.sh
@@ -37,16 +37,42 @@ github_api() {
 }
 
 check_all() {
-    local pass=0 root_release go_release root_sha go_sha
+    local pass=0 root_release latest_release go_release root_sha go_sha
+    local expected_notes actual_notes go_notes
+    local commit_json expected_tree
     root_release="$(github_api \
         "https://api.github.com/repos/rajatim/zhtw/releases/tags/$TAG" 2>/dev/null)" || root_release=''
+    latest_release="$(github_api \
+        "https://api.github.com/repos/rajatim/zhtw/releases/latest" 2>/dev/null)" || latest_release=''
     go_release="$(github_api \
         "https://api.github.com/repos/rajatim/zhtw/releases/tags/sdk%2Fgo%2Fv$VERSION" 2>/dev/null)" || go_release=''
-    [ "$(printf '%s' "$root_release" | jq -r '.tag_name // empty')" = "$TAG" ] && pass=$((pass + 1)) || true
-    [ -n "$(printf '%s' "$root_release" | jq -r '.body // empty' | tr -d '[:space:]')" ] && \
+    printf '%s' "$root_release" | jq -e \
+        --arg tag "$TAG" \
+        '.tag_name == $tag and .name == $tag and .draft == false and .prerelease == false' \
+        >/dev/null && \
+        [ "$(printf '%s' "$latest_release" | jq -r '.tag_name // empty')" = "$TAG" ] && \
         pass=$((pass + 1)) || true
-    [ "$(printf '%s' "$go_release" | jq '[.assets[]? | select(.name | test("^(zhtw-(darwin|linux)-(amd64|arm64)\\.tar\\.gz|zhtw-windows-amd64\\.zip|zhtw_checksums\\.txt)$"))] | length')" = 6 ] && \
+    actual_notes="$(printf '%s' "$root_release" | jq -r '.body // ""')"
+    if [ -n "$PAYLOAD_DIR" ]; then
+        expected_notes="$(cat "$PAYLOAD_DIR/candidate/release-notes.md")"
+        [ "$actual_notes" = "$expected_notes" ] && pass=$((pass + 1)) || true
+    else
+        [ -n "$(printf '%s' "$actual_notes" | tr -d '[:space:]')" ] && pass=$((pass + 1)) || true
+    fi
+    go_notes="$(printf '%s' "$go_release" | jq -r '.body // ""')"
+    if printf '%s' "$go_release" | jq -e \
+        --arg tag "$GO_TAG" \
+        --arg title "Go CLI $TAG" \
+        '.tag_name == $tag and .name == $title and
+         .draft == false and .prerelease == false and
+         ([.assets[]?.name] | sort) == ([
+           "zhtw-darwin-amd64.tar.gz", "zhtw-darwin-arm64.tar.gz",
+           "zhtw-linux-amd64.tar.gz", "zhtw-linux-arm64.tar.gz",
+           "zhtw-windows-amd64.zip", "zhtw_checksums.txt"
+         ] | sort)' >/dev/null && \
+        [ "$go_notes" = "Jenkins-built Go CLI for $TAG." ]; then
         pass=$((pass + 1)) || true
+    fi
     check_url "https://pypi.org/pypi/zhtw/$VERSION/json" && pass=$((pass + 1)) || true
     check_url "https://registry.npmjs.org/zhtw-js/$VERSION" && pass=$((pass + 1)) || true
     check_url "https://registry.npmjs.org/zhtw-wasm/$VERSION" && pass=$((pass + 1)) || true
@@ -59,7 +85,18 @@ check_all() {
 
     root_sha="$(git ls-remote https://github.com/rajatim/zhtw.git "refs/tags/$TAG^{}" | awk '{print $1}')"
     go_sha="$(git ls-remote https://github.com/rajatim/zhtw.git "refs/tags/$GO_TAG^{}" | awk '{print $1}')"
-    [ -n "$root_sha" ] && [ "$root_sha" = "$go_sha" ] && pass=$((pass + 1)) || true
+    if [ -n "$root_sha" ] && [ "$root_sha" = "$go_sha" ]; then
+        if [ -n "$PAYLOAD_DIR" ]; then
+            expected_tree="$(tr -d '[:space:]' < "$PAYLOAD_DIR/metadata/candidate-tree-sha")"
+            commit_json="$(github_api \
+                "https://api.github.com/repos/rajatim/zhtw/git/commits/$root_sha" 2>/dev/null)" || \
+                commit_json=''
+            [ "$(printf '%s' "$commit_json" | jq -r '.tree.sha // empty')" = "$expected_tree" ] && \
+                pass=$((pass + 1)) || true
+        else
+            pass=$((pass + 1))
+        fi
+    fi
     printf '%s\n' "$pass"
 }
 
@@ -152,6 +189,8 @@ verify_exact_payload() (
         download_matches \
             "https://repo1.maven.org/maven2/com/rajatim/zhtw/$VERSION/$name" \
             "$file" "$temporary/$name" || return 1
+        check_url \
+            "https://repo1.maven.org/maven2/com/rajatim/zhtw/$VERSION/$name.asc" || return 1
     done
 
     files=()

--- a/scripts/write-toolchain-evidence.sh
+++ b/scripts/write-toolchain-evidence.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+OUTPUT_FILE="${1:-}"
+[ -n "$OUTPUT_FILE" ] || {
+    echo 'Usage: scripts/write-toolchain-evidence.sh OUTPUT_FILE' >&2
+    exit 64
+}
+
+mkdir -p "$(dirname "$OUTPUT_FILE")"
+
+first_line() {
+    "$@" 2>&1 | sed -n '1p' | tr '\r\n' '  '
+}
+
+required_version() {
+    local name="$1"
+    shift
+    command -v "$1" >/dev/null 2>&1 || {
+        printf 'ERROR: required tool is missing: %s\n' "$1" >&2
+        exit 64
+    }
+    printf '%s=%s\n' "$name" "$(first_line "$@")"
+}
+
+{
+    printf 'SCHEMA_VERSION=1\n'
+    printf 'RECORDED_AT=%s\n' "$(date -u '+%Y-%m-%dT%H:%M:%SZ')"
+    printf 'SOURCE_SHA=%s\n' "${SOURCE_SHA:-unknown}"
+    required_version GIT git --version
+    required_version UV uv --version
+    required_version PYTHON python3 --version
+    required_version JAVA java -version
+    required_version JAVAC javac -version
+    required_version MAVEN mvn --version
+    required_version NODE node --version
+    required_version NPM npm --version
+    required_version PNPM pnpm --version
+    required_version RUSTC rustc --version
+    required_version CARGO cargo --version
+    required_version GO go version
+    required_version DOTNET dotnet --version
+    required_version WASM_PACK wasm-pack --version
+    required_version JQ jq --version
+} > "$OUTPUT_FILE"
+
+chmod 600 "$OUTPUT_FILE"

--- a/tests/test_release_process.py
+++ b/tests/test_release_process.py
@@ -76,6 +76,13 @@ def test_jenkins_build_creates_one_complete_candidate() -> None:
     assert "candidate-tree-sha" in script
     assert "release.patch" in script
     assert "zhtw_checksums.txt" in script
+    assert "smoke_candidate_packages" in script
+    assert "write-toolchain-evidence.sh" in script
+    assert "--no-verify" not in script.split("package_crate()", 1)[1].split("package_nuget()", 1)[0]
+    assert 'dotnet restore "$temporary/dotnet"' in script
+    assert '--source "$OUTPUT_DIR/packages/nuget"' in script
+    assert 'dotnet run --project "$temporary/dotnet" --framework net8.0 --no-restore' in script
+    assert 'java_classpath="$jar:' in script
 
 
 def test_nuget_package_builds_every_target_before_no_build_pack() -> None:
@@ -199,6 +206,9 @@ def test_jenkins_release_is_idempotent_and_covers_every_target() -> None:
         assert f"{action})" in script
     assert "registry_exists" in script
     assert "git push --atomic" in script
+    assert "verify_github_release_metadata" in script
+    assert "Existing GitHub Release notes differ" in script
+    assert "Root GitHub Release is not marked latest" in script
     assert "Existing GitHub asset differs" in script
     assert "Existing PyPI file differs" in script
     assert "Existing npm package differs" in script
@@ -279,7 +289,11 @@ def test_jenkins_verify_uses_isolated_podman_compatible_cli() -> None:
     script = read("scripts/jenkins-verify.sh")
 
     assert "prepare_container_cli" in script
-    assert "--cgroup-manager=cgroupfs --events-backend=file" in script
+    assert "/home/jenkins-agent/.local/run/podman.sock" in script
+    assert "--remote --url %q" in script
+    for isolation in ("XDG_RUNTIME_DIR", "--root", "--runroot", "--tmpdir"):
+        assert isolation in script
+    assert "TESTCONTAINERS_RYUK_DISABLED=true" in script
     assert 'chmod 700 "$runtime_root/bin/docker"' in script
     assert 'export DOCKER_CONFIG="$runtime_root/docker-config"' in script
     assert 'export REGISTRY_AUTH_FILE="$runtime_root/registry-auth.json"' in script
@@ -291,6 +305,10 @@ def test_release_verify_is_read_only_and_version_scoped() -> None:
 
     assert "TOTAL_CHECKS=12" in script
     assert "Exact archived payload matches every public artifact" in script
+    assert "releases/latest" in script
+    assert "candidate-tree-sha" in script
+    assert "git/commits/$root_sha" in script
+    assert "$name.asc" in script
     assert "pypi.org/pypi/zhtw/$VERSION" in script
     assert "registry.npmjs.org/zhtw-js/$VERSION" in script
     assert "repo1.maven.org" in script
@@ -307,9 +325,12 @@ def test_public_release_docs_require_detached_preflight_before_publish() -> None
     for document in (rules, checklist):
         assert "RELEASE_ACTION=CREDENTIAL_PREFLIGHT" in document
         assert "jcli build zhtw/release -s -v" not in document
+        assert "-p BRANCH=main" not in document
+        assert "APPROVAL_REFERENCE" in document
     assert "PREVIEW" in rules
     assert "PUBLISH_ALL" in rules
     assert "RESUME_ALL" in rules
+    assert "每日、每週或 SCM 自動觸發" in rules
     assert rules.index("RELEASE_ACTION=PREVIEW") < rules.index(
         "RELEASE_ACTION=CREDENTIAL_PREFLIGHT"
     )
@@ -338,9 +359,22 @@ if "sdk%2Fgo" in url:
         "zhtw-windows-amd64.zip",
         "zhtw_checksums.txt",
     ]
-    print(json.dumps({"assets": [{"name": name} for name in names]}))
+    print(json.dumps({
+        "tag_name": "sdk/go/v9.8.7",
+        "name": "Go CLI v9.8.7",
+        "body": "Jenkins-built Go CLI for v9.8.7.",
+        "draft": False,
+        "prerelease": False,
+        "assets": [{"name": name} for name in names],
+    }))
 elif "api.github.com" in url:
-    print(json.dumps({"tag_name": "v9.8.7", "body": os.environ.get("RELEASE_BODY", "notes")}))
+    print(json.dumps({
+        "tag_name": "v9.8.7",
+        "name": "v9.8.7",
+        "body": os.environ.get("RELEASE_BODY", "notes"),
+        "draft": False,
+        "prerelease": False,
+    }))
 elif "homebrew-tap" in url:
     print('url "https://files.example/zhtw-9.8.7.tar.gz"')
 elif "nuget.org" in url:

--- a/tests/test_release_process.py
+++ b/tests/test_release_process.py
@@ -81,7 +81,8 @@ def test_jenkins_build_creates_one_complete_candidate() -> None:
     assert "--no-verify" not in script.split("package_crate()", 1)[1].split("package_nuget()", 1)[0]
     assert 'dotnet restore "$temporary/dotnet"' in script
     assert '--source "$OUTPUT_DIR/packages/nuget"' in script
-    assert 'dotnet run --project "$temporary/dotnet" --framework net8.0 --no-restore' in script
+    assert 'dotnet_framework="net${dotnet_major}.0"' in script
+    assert 'dotnet run --project "$temporary/dotnet" --framework "$dotnet_framework"' in script
     assert 'java_classpath="$jar:' in script
 
 

--- a/tests/test_release_process.py
+++ b/tests/test_release_process.py
@@ -84,6 +84,8 @@ def test_jenkins_build_creates_one_complete_candidate() -> None:
     assert 'dotnet_framework="net${dotnet_major}.0"' in script
     assert 'dotnet run --project "$temporary/dotnet" --framework "$dotnet_framework"' in script
     assert 'java_classpath="$jar:' in script
+    assert 'Darwin-arm64) go_platform="darwin-arm64"' in script
+    assert 'Linux-x86_64) go_platform="linux-amd64"' in script
 
 
 def test_nuget_package_builds_every_target_before_no_build_pack() -> None:


### PR DESCRIPTION
## 摘要

- 將 zhtw build、verify、release 明確定義為發版時手動執行。
- 新增所有封存套件的 consumer smoke test 與 toolchain 證據。
- 強化 verification receipt、GitHub Release metadata、candidate tree、Maven 簽章與恢復驗證。
- 修正 NuGet local-only restore、Java classpath、跨 .NET SDK 與原生 Go CLI 測試。

## 驗證

- `make release-gate`：Python 5,509、Java 159、TypeScript 162、Rust、Go race/vet/lint、.NET 26 全數通過。
- `tests/test_release_process.py`：42 passed。
- 隔離的 4.4.6 candidate dry run：全部套件打包、安裝、執行、checksum 與乾淨 checkout 重建均通過。

## 安全邊界

本 PR 沒有建立 tag、沒有發布套件，也沒有更新線上 Jenkins job。合併後仍需先合併配套的 `jenkins-cicd` PR，再由 source-controlled job XML 套用。
